### PR TITLE
Tooltip right position fix

### DIFF
--- a/src/tooltip.js
+++ b/src/tooltip.js
@@ -80,7 +80,7 @@ class Tooltip {
 
         if(position == 'right') {
             p = {
-                top: baseTop + rect.y + this.tooltip.offsetHeight - spacing + 'px',
+                top: baseTop + rect.y + (rect.height - this.tooltip.offsetHeight)/2 + 'px',
                 left: rect.x + rect.width + spacing + 'px'
             }
         }


### PR DESCRIPTION
The tooltip when set to be positioned on the right was not vertically centered. 

This fix remedies that.

Fixes issue #1 