### PR TITLE
Updated tooltip to use Tailwind v1 colour

### DIFF
--- a/src/tooltip.js
+++ b/src/tooltip.js
@@ -1,4 +1,4 @@
-const classes = 'bg-black text-xs px-2 leading-normal py-1 rounded absolute text-grey-light max-w-xs';
+const classes = 'bg-black text-xs px-2 leading-normal py-1 rounded absolute text-gray-400 max-w-xs';
 const spacing = 5;
 
 class Tooltip {


### PR DESCRIPTION
Colour used is from the beta version of Tailwind. The colours were changed from text-grey-lighter to text-gray-400.